### PR TITLE
[WIP] API Gateway access restriction

### DIFF
--- a/lambda-api-gateway-authorizer/index.js
+++ b/lambda-api-gateway-authorizer/index.js
@@ -1,0 +1,61 @@
+var jwt = require('jsonwebtoken');
+var request = require('request');
+var jwkToPem = require('jwk-to-pem');
+var jwksClient = require('jwks-rsa');
+
+var iss = 'https://cognito-idp.eu-central-1.amazonaws.com/eu-central-1_jsJkz5UA3';
+var jwkUrl = iss + '/.well-known/jwks.json';
+var aud = 'd4a0b03d-c602-483b-91d3-829ac7de5175';
+
+exports.handler = function(event, context, callback) {
+    validateToken(event, context, callback);
+};
+
+function validateToken(event, context, callback) {
+    var token = event.authorizationToken;
+
+    var options = {
+      issuer: iss,
+      audience: aud,
+      ignoreExpiration: true
+    };
+    var client = jwksClient({
+      jwksUri: jwkUrl
+    });
+    function getKey(header, callback){
+      client.getSigningKey(header.kid, function(err, key) {
+        var signingKey = key.publicKey || key.rsaPublicKey;
+        callback(null, signingKey);
+      });
+    }
+
+    jwt.verify(token, getKey, options, function(err, decoded) {
+      console.log(decoded);
+
+      if (err === null || err === undefined) {
+        callback(null, generatePolicy('user', 'Allow', event.methodArn));
+      } else {
+        callback("Unauthorized");   // Return a 401 Unauthorized response
+      }
+    });
+};
+
+// helper function to generate an IAM policy
+var generatePolicy = function(principalId, effect, resource) {
+    var authResponse = {};
+    
+    authResponse.principalId = principalId;
+    if (effect && resource) {
+        var policyDocument = {};
+        policyDocument.Version = '2012-10-17'; 
+        policyDocument.Statement = [];
+        var statementOne = {};
+        statementOne.Action = 'execute-api:Invoke'; 
+        statementOne.Effect = effect;
+        statementOne.Resource = resource;
+        policyDocument.Statement[0] = statementOne;
+        authResponse.policyDocument = policyDocument;
+    }
+    
+    return authResponse;
+}

--- a/lambda-api-gateway-authorizer/package.json
+++ b/lambda-api-gateway-authorizer/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "vagabundo-api-gateway-authorizer",
+  "version": "0.0.1",
+  "scripts": {
+    "clean": "rm -rf dist/ node_modules/",
+    "package": "mkdir -p dist && zip -r dist/authorizer.zip . -x *dist/*",
+    "upload": "npm run package && aws lambda update-function-code --function-name authorizer --zip-file fileb:///Users/dkirsten/git/vagabundo-aws/lambda-api-gateway-authorizer/dist/authorizer.zip"
+  },
+  "dependencies": {
+    "jsonwebtoken": "^8.5.0",
+    "jwk-to-pem": "^2.0.1",
+    "jwks-rsa": "^1.4.0",
+    "request": "^2.88.0"
+  }
+}


### PR DESCRIPTION
Attempts to solve https://trello.com/c/ldKXoitA

So, _in principle_ this works. The function validates the token and can be included in an API Gateway.
However, there is still some stuff to do:

- [ ] For some reason now the lambda is not recognized anymore because of the handler: `Unable to import module 'index': Error`
- [ ] We should have two lambdas with the same code base here. The second one should simply check if the payload user is equal to the businessKey thing, so we can restrict more stricly some user-dependent routes
- [ ] `package.json` is at the momentan dependant on my machine. Should be at least documented.
- [ ] Research if there is a nice (script...) way to include the Authenticator in the API GAteway description